### PR TITLE
optimisation ideas

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,35 +1,36 @@
-function SmartInterval(asyncFn, delayMs) {
-    this.asyncFn = asyncFn;
-    this.delayMs = delayMs;
-
-    this.running = false;
+export function SmartInterval(asyncFn, delayMs) {
+  this.asyncFn = asyncFn;
+  this.delayMs = delayMs;
+  this.running = false;
 }
 
 SmartInterval.prototype.cycle = async function (forced) {
-    await this.asyncFn();
-    await this.delay(this.delayMs);
-    if (!forced && this.running) this.cycle();
+  if (!this.running && !forced) return;
+  await this.delay(this.delayMs);
+  this.running && (await this.asyncFn());
+  if (!forced && this.running) this.cycle();
 };
 
 SmartInterval.prototype.start = function () {
-    if (this.running) return;
-    this.running = true;
-    this.cycle();
+  if (this.running) return;
+  this.running = true;
+  this.cycle();
 };
 
 SmartInterval.prototype.stop = function () {
-    if (this.running) this.running = false;
+  if (this.running) this.running = false;
 };
 
 SmartInterval.prototype.forceExecution = function () {
-    if (this.running) this.cycle(true);
+  if (this.running) this.cycle(true);
 };
 
 // This function is just an arbitrary delay to be used with async/await pattern
 SmartInterval.prototype.delay = function (ms) {
-    return new Promise(res =>
-        setTimeout(() => res(1), ms)
-    );
+  let timeout;
+  return new Promise((res) => {
+    timeout = setTimeout(() => res(1), ms);
+  }).then(() => clearInterval(timeout));
 };
 
-module.exports = SmartInterval;
+export default SmartInterval;


### PR DESCRIPTION
was thinking `SmartInterval.prototype.delay` should `clearInterval` for better garbage collection?

think cycle method should exec the fun after delay like setInterval, and found it ran once extra on call to .stop unless added is running condition `this.running && (await this.asyncFn());`